### PR TITLE
rpcs3: Update dependencies

### DIFF
--- a/bucket/rpcs3.json
+++ b/bucket/rpcs3.json
@@ -7,17 +7,17 @@
         "url": "https://github.com/RPCS3/rpcs3/blob/master/LICENSE"
     },
     "suggest": {
-        "Microsoft Visual C++ Runtime 2015": "extras/vcredist2015"
+        "Microsoft Visual C++ Runtime 2019": "extras/vcredist2019"
     },
     "architecture": {
         "64bit": {
             "url": [
                 "https://github.com/RPCS3/rpcs3-binaries-win/releases/download/build-074b9f94db23af0b971d0182c93dc7449a185fef/rpcs3-v0.0.9-1021-074b9f94_win64.7z",
-                "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2019_0214_da485a99e39105b2ccffa5af59f82221/PS3UPDAT.PUP"
+                "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2020_0331_cf9cb4ba53a83ad557501417837c8de9/PS3UPDAT.PUP"
             ],
             "hash": [
                 "06dee991eed27bc50e1eddf530efbb1da488d8d13ca39ab74a41eb239da47918",
-                "3bd059c6fdc9757aa59db921ab4ff1743134801de7e00e814efd57621471823f"
+                "14AD0A4716D2BDF096DAB9ECF77B9B838CC64435DB7925837A38979FA05F4012"
             ]
         }
     },


### PR DESCRIPTION
- Bump PS3UPDAT.PUP to 4.86
- Suggest vcredist2019